### PR TITLE
Incluindo o munifacil

### DIFF
--- a/inst/dados.csv
+++ b/inst/dados.csv
@@ -101,3 +101,4 @@ Fundamentos de Estatística para Ciência de Dados,http://filipezabala.com/fdepc
 Pacote {siconvr},https://fmeireles.com/siconvr/,Pacotes da comunidade, Base de dados, Fernando Meireles e Marcus Vinícius de Sá Torres,Inglês
 Amostragem com R,https://amostragemcomr.github.io/livro/,Livros,Estatística,Pedro Luis do Nascimento Silva - Zélia Magalhães Bianchini - Antonio José Ribeiro Dias,Português
 R for Data Science 2ed (em escrita),https://r4ds.hadley.nz/index.html,Livros,Programação em R,Hadley Wickham and Garrett Grolemund,Inglês
+Pacote {munifacil},https://github.com/curso-r/munifacil,Pacotes da comunidade,Faxina de dados,Julio Trecenti e Fernando Corrêa,Português 


### PR DESCRIPTION
Inclui o pacote munifacil no arquivo "dados.csv" nos temas "pacotes da comunidade" e subtema "faxina de dados"