### PR TITLE
Adicionar R Journal como revista científica

### DIFF
--- a/inst/dados.csv
+++ b/inst/dados.csv
@@ -103,3 +103,4 @@ Pacote {siconvr},https://fmeireles.com/siconvr/,Pacotes da comunidade, Base de d
 Amostragem com R,https://amostragemcomr.github.io/livro/,Livros,Estatística,Pedro Luis do Nascimento Silva - Zélia Magalhães Bianchini - Antonio José Ribeiro Dias,Português
 R for Data Science 2ed (em escrita),https://r4ds.hadley.nz/index.html,Livros,Programação em R,Hadley Wickham and Garrett Grolemund,Inglês
 Pacote {munifacil},https://github.com/curso-r/munifacil,Pacotes da comunidade,Faxina de dados,Julio Trecenti e Fernando Corrêa,Português 
+The R Journal,https://journal.r-project.org/,Revistas científicas,Programação em R,R Project,Inglês


### PR DESCRIPTION
Adicionar The R Journal em nova categoria entitulada Revistas científicas, no tema Programação em R, no idioma inglês.

Iniciar processo de adição falado em #30 